### PR TITLE
Add V8 inspector/debugger

### DIFF
--- a/src/CV8Resource.cpp
+++ b/src/CV8Resource.cpp
@@ -25,6 +25,8 @@
 #include "helpers/V8Helpers.h"
 #include "helpers/V8Module.h"
 
+#include "inspector/CV8InspectorClient.h"
+
 static void StaticRequire(const v8::FunctionCallbackInfo<v8::Value> &info)
 {
 	v8::Isolate *isolate = info.GetIsolate();
@@ -153,6 +155,9 @@ bool CV8ResourceImpl::Stop()
 	// }
 
 	//runtime->GetInspector()->contextDestroyed(context.Get(isolate));
+
+	// Remove the inspector
+	if (inspector) delete inspector;
 
 	if (!context.IsEmpty())
 	{

--- a/src/CV8Resource.cpp
+++ b/src/CV8Resource.cpp
@@ -64,16 +64,13 @@ bool CV8ResourceImpl::Start()
 
 	V8ResourceImpl::Start();
 
-	v8::Context::Scope context_scope(ctx);
-
 	//Log::Debug(V8ResourceImpl::GetResource(ctx));
 	//Log::Debug(V8ResourceImpl::GetResource(isolate->GetEnteredContext()));
 
-	/*runtime->GetInspector()->contextCreated({
-		ctx,
-		1,
-		v8_inspector::StringView{ (uint8_t*)name.CStr(), name.GetSize() }
-	});*/
+	// Start V8 inspector
+	inspector = new CV8InspectorClient(context.Get(isolate), alt::ICore::Instance().IsDebug());
+
+	v8::Context::Scope context_scope(ctx);
 
 	std::string path = resource->GetMain().ToString();
 

--- a/src/CV8Resource.h
+++ b/src/CV8Resource.h
@@ -9,6 +9,8 @@
 
 #include "helpers/Log.h"
 
+#include "inspector/CV8InspectorClient.h";
+
 class CV8ScriptRuntime;
 
 class CV8ResourceImpl : public V8ResourceImpl
@@ -90,10 +92,16 @@ public:
 	v8::MaybeLocal<v8::Module> ResolveFile(const std::string &name, v8::Local<v8::Module> referrer);
 	v8::MaybeLocal<v8::Module> ResolveModule(const std::string &name, v8::Local<v8::Module> referrer);
 
+	CV8InspectorClient* GetInspector()
+	{ 
+		return inspector; 
+	}
+
 private:
 	using WebViewEvents = std::unordered_multimap<std::string, V8::EventCallback>;
 
 	CV8ScriptRuntime *runtime;
+	CV8InspectorClient *inspector;
 
 	std::unordered_map<std::string, v8::UniquePersistent<v8::Value>> requires;
 	std::unordered_map<std::string, v8::UniquePersistent<v8::Module>> modules;

--- a/src/CV8Resource.h
+++ b/src/CV8Resource.h
@@ -12,6 +12,7 @@
 #include "inspector/CV8InspectorClient.h"
 
 class CV8ScriptRuntime;
+class CV8InspectorClient;
 
 class CV8ResourceImpl : public V8ResourceImpl
 {

--- a/src/CV8Resource.h
+++ b/src/CV8Resource.h
@@ -9,7 +9,7 @@
 
 #include "helpers/Log.h"
 
-#include "inspector/CV8InspectorClient.h";
+#include "inspector/CV8InspectorClient.h"
 
 class CV8ScriptRuntime;
 

--- a/src/CV8ScriptRuntime.cpp
+++ b/src/CV8ScriptRuntime.cpp
@@ -59,20 +59,6 @@ CV8ScriptRuntime::CV8ScriptRuntime()
 		return v8::MaybeLocal<v8::Promise>();
 	});*/
 
-	/*{
-		v8::Locker locker(isolate);
-		v8::Isolate::Scope isolate_scope(isolate);
-		v8::HandleScope handle_scope(isolate);
-
-		inspectorClient.reset(new alt::CV8InspectorClient);
-		inspectorChannel.reset(new alt::CV8InspectorChannel);
-
-		inspector = v8_inspector::V8Inspector::create(isolate, inspectorClient.get());
-
-		v8_inspector::StringView inspectorView{ (uint8_t*)inspectorViewStr, strlen(inspectorViewStr) };
-		inspectorSession = inspector->connect(1, inspectorChannel.get(), inspectorView);
-	}*/
-
 	{
 		v8::Locker locker(isolate);
 		v8::Isolate::Scope isolate_scope(isolate);

--- a/src/CV8ScriptRuntime.h
+++ b/src/CV8ScriptRuntime.h
@@ -7,6 +7,7 @@
 #include "cpp-sdk/IScriptRuntime.h"
 
 #include "CV8Resource.h"
+#include "inspector/CV8InspectorClient.h";
 
 class CV8ScriptRuntime : public alt::IScriptRuntime
 {
@@ -15,17 +16,11 @@ class CV8ScriptRuntime : public alt::IScriptRuntime
 	std::unique_ptr<v8::Platform> platform;
 	v8::Isolate::CreateParams create_params;
 	v8::Isolate *isolate;
-	std::unique_ptr<v8_inspector::V8InspectorClient> inspectorClient;
-	std::unique_ptr<v8_inspector::V8Inspector::Channel> inspectorChannel;
-	std::unique_ptr<v8_inspector::V8Inspector> inspector;
-	std::unique_ptr<v8_inspector::V8InspectorSession> inspectorSession;
 
 public:
 	CV8ScriptRuntime();
 
 	v8::Isolate *GetIsolate() const { return isolate; }
-
-	v8_inspector::V8Inspector *GetInspector() const { return inspector.get(); }
 
 	alt::IResource::Impl *CreateImpl(alt::IResource *resource) override
 	{

--- a/src/bindings/Inspector.cpp
+++ b/src/bindings/Inspector.cpp
@@ -5,8 +5,7 @@
 #include "cpp-sdk/SDK.h"
 
 #include "../inspector/CV8InspectorClient.h"
-
-extern class CV8ResourceImpl;
+#include "../CV8Resource.h"
 
 /*static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
@@ -22,10 +21,11 @@ extern class CV8ResourceImpl;
 
 static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
-	V8_CHECK(alt::ICore::Instance().IsDebug(), "The inspector is only available in debug mode");
 	V8_GET_ISOLATE_CONTEXT();
+	V8_CHECK(alt::ICore::Instance().IsDebug(), "The inspector is only available in debug mode");
 	V8_CHECK_ARGS_LEN2(1, 2);
 	V8_ARG_TO_STRING(1, method);
+
 	v8::Local<v8::Object> params = v8::Object::New(isolate);
 	if (info.Length() == 2) 
 	{

--- a/src/bindings/Inspector.cpp
+++ b/src/bindings/Inspector.cpp
@@ -38,9 +38,22 @@ static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info
 	info.GetReturnValue().Set(promise);
 }
 
+static void SendInspectorMessageRaw(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+	V8_GET_ISOLATE_CONTEXT();
+	V8_CHECK(alt::ICore::Instance().IsDebug(), "The inspector is only available in debug mode");
+	V8_CHECK_ARGS_LEN(1);
+	V8_ARG_TO_STRING(1, message);
+
+	auto promise = CV8InspectorClient::SendInspectorMessage(isolate, message);
+
+	info.GetReturnValue().Set(promise);
+}
+
 extern V8Class v8Inspector("Inspector", nullptr, [](v8::Local<v8::FunctionTemplate> tpl) {
 	v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
 	//V8::SetStaticMethod(isolate, tpl, "setCallback", &SetInspectorCallback);
 	V8::SetStaticMethod(isolate, tpl, "sendMessage", &SendInspectorMessage);
+	V8::SetStaticMethod(isolate, tpl, "sendMessageRaw", &SendInspectorMessageRaw);
 });

--- a/src/bindings/Inspector.cpp
+++ b/src/bindings/Inspector.cpp
@@ -1,0 +1,25 @@
+#include "../helpers/V8Class.h"
+#include "../helpers/V8Helpers.h"
+#include "../helpers/V8ResourceImpl.h"
+#include "../CV8Resource.h"
+#include "cpp-sdk/SDK.h"
+#include "inspector/CV8InspectorClient.h"
+
+static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+	V8_GET_ISOLATE_CONTEXT();
+	V8_CHECK_ARGS_LEN(1);
+	V8_ARG_TO_FUNCTION(1, callback);
+
+	auto res = static_cast<CV8ResourceImpl*>(CV8ResourceImpl::Get(ctx));
+	res->GetInspector()->SetCallback(callback, isolate);
+
+	V8_RETURN(v8::Undefined(isolate));
+}
+
+extern V8Class v8Inspector("Inspector", nullptr, [](v8::Local<v8::FunctionTemplate> tpl) {
+	v8::Isolate* isolate = v8::Isolate::GetCurrent();
+
+	V8::SetStaticMethod(isolate, tpl, "setCallback", &SetInspectorCallback);
+	V8::SetStaticMethod(isolate, tpl, "sendMessage", &CV8InspectorClient::SendInspectorMessage);
+});

--- a/src/bindings/Inspector.cpp
+++ b/src/bindings/Inspector.cpp
@@ -22,6 +22,7 @@ extern class CV8ResourceImpl;
 
 static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
+	V8_CHECK(alt::ICore::Instance().IsDebug(), "The inspector is only available in debug mode");
 	V8_GET_ISOLATE_CONTEXT();
 	V8_CHECK_ARGS_LEN2(1, 2);
 	V8_ARG_TO_STRING(1, method);

--- a/src/bindings/Inspector.cpp
+++ b/src/bindings/Inspector.cpp
@@ -7,17 +7,15 @@
 #include "../inspector/CV8InspectorClient.h"
 #include "../CV8Resource.h"
 
-/*static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info)
+static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
 	V8_GET_ISOLATE_CONTEXT();
 	V8_CHECK_ARGS_LEN(1);
 	V8_ARG_TO_FUNCTION(1, callback);
 
 	auto res = static_cast<CV8ResourceImpl*>(CV8ResourceImpl::Get(ctx));
-	res->GetInspector()->SetCallback(callback, isolate);
-
-	V8_RETURN(v8::Undefined(isolate));
-}*/
+	res->GetInspector()->SetCallback(isolate, callback);
+}
 
 static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
@@ -35,7 +33,7 @@ static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info
 
 	auto promise = CV8InspectorClient::SendInspectorMessage(isolate, method, params);
 
-	info.GetReturnValue().Set(promise);
+	V8_RETURN(promise);
 }
 
 static void SendInspectorMessageRaw(const v8::FunctionCallbackInfo<v8::Value>& info)
@@ -53,7 +51,7 @@ static void SendInspectorMessageRaw(const v8::FunctionCallbackInfo<v8::Value>& i
 extern V8Class v8Inspector("Inspector", nullptr, [](v8::Local<v8::FunctionTemplate> tpl) {
 	v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
-	//V8::SetStaticMethod(isolate, tpl, "setCallback", &SetInspectorCallback);
+	V8::SetStaticMethod(isolate, tpl, "setEventCallback", &SetInspectorCallback);
 	V8::SetStaticMethod(isolate, tpl, "sendMessage", &SendInspectorMessage);
 	V8::SetStaticMethod(isolate, tpl, "sendMessageRaw", &SendInspectorMessageRaw);
 });

--- a/src/bindings/Inspector.cpp
+++ b/src/bindings/Inspector.cpp
@@ -25,11 +25,12 @@ static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info
 	V8_GET_ISOLATE_CONTEXT();
 	V8_CHECK_ARGS_LEN2(1, 2);
 	V8_ARG_TO_STRING(1, method);
-	v8::Local<v8::Object> params;
-	if (info.Length() == 2)
-		V8_CHECK(V8::SafeToObject(info[2 - 1], ctx, params), "Failed to convert argument 2 to object")
-	else 
-		params = v8::Object::New(isolate);
+	v8::Local<v8::Object> params = v8::Object::New(isolate);
+	if (info.Length() == 2) 
+	{
+		bool result = V8::SafeToObject(info[2 - 1], ctx, params);
+		V8_CHECK(result, "Failed to convert argument 2 to object")
+	}
 
 	auto promise = CV8InspectorClient::SendInspectorMessage(isolate, method, params);
 

--- a/src/bindings/Inspector.cpp
+++ b/src/bindings/Inspector.cpp
@@ -8,7 +8,7 @@
 
 extern class CV8ResourceImpl;
 
-static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info)
+/*static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
 	V8_GET_ISOLATE_CONTEXT();
 	V8_CHECK_ARGS_LEN(1);
@@ -18,11 +18,27 @@ static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info
 	res->GetInspector()->SetCallback(callback, isolate);
 
 	V8_RETURN(v8::Undefined(isolate));
+}*/
+
+static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+	V8_GET_ISOLATE_CONTEXT();
+	V8_CHECK_ARGS_LEN2(1, 2);
+	V8_ARG_TO_STRING(1, method);
+	v8::Local<v8::Object> params;
+	if (info.Length() == 2)
+		V8_CHECK(V8::SafeToObject(info[2 - 1], ctx, params), "Failed to convert argument 2 to object")
+	else 
+		params = v8::Object::New(isolate);
+
+	auto promise = CV8InspectorClient::SendInspectorMessage(isolate, method, params);
+
+	info.GetReturnValue().Set(promise);
 }
 
 extern V8Class v8Inspector("Inspector", nullptr, [](v8::Local<v8::FunctionTemplate> tpl) {
 	v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
-	V8::SetStaticMethod(isolate, tpl, "setCallback", &SetInspectorCallback);
-	V8::SetStaticMethod(isolate, tpl, "sendMessage", &CV8InspectorClient::SendInspectorMessage);
+	//V8::SetStaticMethod(isolate, tpl, "setCallback", &SetInspectorCallback);
+	V8::SetStaticMethod(isolate, tpl, "sendMessage", &SendInspectorMessage);
 });

--- a/src/bindings/Inspector.cpp
+++ b/src/bindings/Inspector.cpp
@@ -3,7 +3,10 @@
 #include "../helpers/V8ResourceImpl.h"
 #include "../CV8Resource.h"
 #include "cpp-sdk/SDK.h"
-#include "inspector/CV8InspectorClient.h"
+
+#include "../inspector/CV8InspectorClient.h"
+
+extern class CV8ResourceImpl;
 
 static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info)
 {

--- a/src/bindings/Main.cpp
+++ b/src/bindings/Main.cpp
@@ -660,18 +660,6 @@ static void TakeScreenshotGameOnly(const v8::FunctionCallbackInfo<v8::Value> &in
 	V8_RETURN(persistent.Get(isolate)->GetPromise());
 }
 
-static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info)
-{
-	V8_GET_ISOLATE_CONTEXT();
-	V8_CHECK_ARGS_LEN(1);
-	V8_ARG_TO_FUNCTION(1, callback);
-
-	auto res = static_cast<CV8ResourceImpl*>(CV8ResourceImpl::Get(ctx));
-	res->GetInspector()->SetCallback(callback, isolate);
-
-	V8_RETURN(v8::Undefined(isolate));
-}
-
 extern V8Class v8Vector3,
 	v8RGBA,
 	v8BaseObject,

--- a/src/bindings/Main.cpp
+++ b/src/bindings/Main.cpp
@@ -7,6 +7,8 @@
 
 #include "../helpers/Log.h"
 
+#include "../CV8Resource.h";
+
 using namespace alt;
 
 static void OnServer(const v8::FunctionCallbackInfo<v8::Value> &info)
@@ -658,6 +660,18 @@ static void TakeScreenshotGameOnly(const v8::FunctionCallbackInfo<v8::Value> &in
 	V8_RETURN(persistent.Get(isolate)->GetPromise());
 }
 
+static void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+	V8_GET_ISOLATE_CONTEXT();
+	V8_CHECK_ARGS_LEN(1);
+	V8_ARG_TO_FUNCTION(1, callback);
+
+	auto res = static_cast<CV8ResourceImpl*>(CV8ResourceImpl::Get(ctx));
+	res->GetInspector()->SetCallback(callback, isolate);
+
+	V8_RETURN(v8::Undefined(isolate));
+}
+
 extern V8Class v8Vector3,
 	v8RGBA,
 	v8BaseObject,
@@ -774,4 +788,5 @@ extern V8Module altModule(
 
 		V8Helpers::RegisterFunc(exports, "takeScreenshot", &TakeScreenshot);
 		V8Helpers::RegisterFunc(exports, "takeScreenshotGameOnly", &TakeScreenshotGameOnly);
+		V8Helpers::RegisterFunc(exports, "setInspectorCallback", &SetInspectorCallback);
 	});

--- a/src/bindings/Main.cpp
+++ b/src/bindings/Main.cpp
@@ -693,7 +693,8 @@ extern V8Class v8Vector3,
 	v8Discord,
 	v8Voice,
 	v8PedBlip,
-	v8VehicleBlip;
+	v8VehicleBlip,
+	v8Inspector;
 extern V8Module altModule(
 	"alt",
 	{v8Vector3,
@@ -714,7 +715,8 @@ extern V8Module altModule(
 	 v8File,
 	 //  v8MapZoomData,
 	 v8Discord,
-	 v8Voice},
+	 v8Voice,
+	 v8Inspector},
 	[](v8::Local<v8::Context> ctx, v8::Local<v8::Object> exports) {
 		V8::RegisterSharedMain(ctx, exports);
 
@@ -788,5 +790,4 @@ extern V8Module altModule(
 
 		V8Helpers::RegisterFunc(exports, "takeScreenshot", &TakeScreenshot);
 		V8Helpers::RegisterFunc(exports, "takeScreenshotGameOnly", &TakeScreenshotGameOnly);
-		V8Helpers::RegisterFunc(exports, "setInspectorCallback", &SetInspectorCallback);
 	});

--- a/src/inspector/CV8InspectorChannel.cpp
+++ b/src/inspector/CV8InspectorChannel.cpp
@@ -35,7 +35,7 @@ void CV8InspectorChannel::Send(int id, const v8_inspector::StringView& string)
         v8::Local<v8::Object> result = v8::JSON::Parse(context, message).ToLocalChecked().As<v8::Object>();
         v8::MaybeLocal<v8::Value> error = result->Get(context, v8::String::NewFromUtf8(isolate, "error").ToLocalChecked());
         v8::Local<v8::Value> errorObj;
-        if (error.ToLocal(&errorObj))
+        if (error.ToLocal(&errorObj) && errorObj.As<v8::Object>()->HasOwnProperty(context, v8::String::NewFromUtf8(isolate, "code").ToLocalChecked()).ToChecked())
             promise->Reject(context, errorObj);
         else
             promise->Resolve(context, result);

--- a/src/inspector/CV8InspectorChannel.cpp
+++ b/src/inspector/CV8InspectorChannel.cpp
@@ -1,0 +1,38 @@
+
+#include "v8-inspector.h";
+#include "../helpers/V8Helpers.h";
+#include "CV8InspectorChannel.h";
+
+void CV8InspectorChannel::Send(const v8_inspector::StringView& string)
+{
+    auto isolate = _isolate;
+    v8::Isolate::AllowJavascriptExecutionScope allow_script(isolate);
+    v8::HandleScope handle_scope(isolate);
+
+    int length = static_cast<int>(string.length());
+    V8_CHECK(length < v8::String::kMaxLength, "Message too long");
+
+    v8::Local<v8::String> message =
+        (string.is8Bit()
+            ? v8::String::NewFromOneByte(
+                isolate,
+                reinterpret_cast<const uint8_t*>(string.characters8()),
+                v8::NewStringType::kNormal, length)
+            : v8::String::NewFromTwoByte(
+                isolate,
+                reinterpret_cast<const uint16_t*>(string.characters16()),
+                v8::NewStringType::kNormal, length))
+        .ToLocalChecked();
+
+    v8::Local<v8::Context> context = _context.Get(isolate);
+    v8::Local<v8::Function> callback = _client->GetCallback(isolate);
+    auto type = callback->TypeOf(isolate);
+    v8::String::Utf8Value utfValue(isolate, type);
+    std::string name(*utfValue);
+
+    if (callback->IsFunction()) {
+        v8::TryCatch try_catch(isolate);
+        v8::Local<v8::Value> args[] = { message };
+        v8::Local<v8::Function>::Cast(callback)->Call(context, v8::Undefined(isolate), 1, args);
+    }
+}

--- a/src/inspector/CV8InspectorChannel.cpp
+++ b/src/inspector/CV8InspectorChannel.cpp
@@ -33,7 +33,7 @@ void CV8InspectorChannel::Send(int id, const v8_inspector::StringView& string)
         v8::Local<v8::Context> context = isolate->GetEnteredContext();
 
         v8::Local<v8::Object> result = v8::JSON::Parse(context, message).ToLocalChecked().As<v8::Object>();
-        v8::MaybeLocal<v8::Value> error = result->Get(context, v8::String::NewFromUtf8(isolate, "error").ToLocalChecked()).As<v8::Object>();
+        v8::MaybeLocal<v8::Value> error = result->Get(context, v8::String::NewFromUtf8(isolate, "error").ToLocalChecked());
         v8::Local<v8::Value> errorObj;
         if (error.ToLocal(&errorObj))
             promise->Reject(context, errorObj);

--- a/src/inspector/CV8InspectorChannel.cpp
+++ b/src/inspector/CV8InspectorChannel.cpp
@@ -42,3 +42,39 @@ void CV8InspectorChannel::Send(int id, const v8_inspector::StringView& string)
         CV8InspectorClient::promises.erase(static_cast<uint32_t>(id));
     }
 }
+
+void CV8InspectorChannel::SendEvent(const v8_inspector::StringView& string)
+{
+    auto isolate = _isolate;
+    v8::Isolate::AllowJavascriptExecutionScope allow_script(isolate);
+    v8::HandleScope handle_scope(isolate);
+
+    int length = static_cast<int>(string.length());
+    V8_CHECK(length < v8::String::kMaxLength, "Message too long");
+
+    v8::Local<v8::String> message =
+        (string.is8Bit()
+            ? v8::String::NewFromOneByte(
+                isolate,
+                reinterpret_cast<const uint8_t*>(string.characters8()),
+                v8::NewStringType::kNormal, length)
+            : v8::String::NewFromTwoByte(
+                isolate,
+                reinterpret_cast<const uint16_t*>(string.characters16()),
+                v8::NewStringType::kNormal, length))
+        .ToLocalChecked();
+
+    v8::Local<v8::Context> context = isolate->GetEnteredContext();
+
+    CV8ResourceImpl* resource = static_cast<CV8ResourceImpl*>(V8ResourceImpl::Get(context));
+    auto callback = resource->GetInspector()->GetCallback(isolate);
+
+    if(!callback.IsEmpty())
+    {
+        v8::TryCatch try_catch(isolate);
+
+        v8::Local<v8::Object> result = v8::JSON::Parse(context, message).ToLocalChecked().As<v8::Object>();
+        v8::Local<v8::Value> args[] = { message };
+        callback->Call(context, v8::Undefined(isolate), 1, args);
+    }
+}

--- a/src/inspector/CV8InspectorChannel.cpp
+++ b/src/inspector/CV8InspectorChannel.cpp
@@ -33,7 +33,7 @@ void CV8InspectorChannel::Send(int id, const v8_inspector::StringView& string)
         v8::Local<v8::Context> context = isolate->GetEnteredContext();
 
         v8::Local<v8::Object> result = v8::JSON::Parse(context, message).ToLocalChecked().As<v8::Object>();
-        v8::MaybeLocal<v8::Value> error = result->Get(context, v8::String::NewFromUtf8(isolate, "error").ToLocalChecked());
+        v8::MaybeLocal<v8::Value> error = result->Get(context, v8::String::NewFromUtf8(isolate, "error").ToLocalChecked()).As<v8::Object>();
         v8::Local<v8::Value> errorObj;
         if (error.ToLocal(&errorObj))
             promise->Reject(context, errorObj);

--- a/src/inspector/CV8InspectorChannel.h
+++ b/src/inspector/CV8InspectorChannel.h
@@ -23,18 +23,20 @@ private:
     void sendResponse(int callId, std::unique_ptr<v8_inspector::StringBuffer> message) override 
     {
         //Log::Info << __FUNCTION__ << " ID: " << callId << Log::Endl;;
-        Send(message->string());
+        Send(callId, message->string());
     }
     void sendNotification(std::unique_ptr<v8_inspector::StringBuffer> message) override 
     {
         //Log::Info << __FUNCTION__ << Log::Endl;
-        Send(message->string());
+
+        // TODO: Fix notifications sent by the inspector
+        //Send(-1, message->string());
     }
     void flushProtocolNotifications() override 
     {
         //Log::Info << __FUNCTION__ << Log::Endl;
     }
-    void Send(const v8_inspector::StringView& string);
+    void Send(int id, const v8_inspector::StringView& string);
 
     v8::Isolate* _isolate;
     v8::Global<v8::Context> _context;

--- a/src/inspector/CV8InspectorChannel.h
+++ b/src/inspector/CV8InspectorChannel.h
@@ -1,24 +1,42 @@
 #pragma once
 
 #include "v8-inspector.h"
+#include "../helpers/V8Helpers.h"
+#include "CV8InspectorClient.h";
 
-namespace alt
+class CV8InspectorChannel : public v8_inspector::V8Inspector::Channel
 {
-	class CV8InspectorChannel : public v8_inspector::V8Inspector::Channel
-	{
-		void sendResponse(int callId, std::unique_ptr<v8_inspector::StringBuffer> message)
-		{
-			Log::Debug << __FUNCTION__ << callId << message->string().characters8();
-		}
+public:
+	explicit CV8InspectorChannel(v8::Local<v8::Context> context, CV8InspectorClient* client)
+    {
+		_isolate = context->GetIsolate();
+		_context.Reset(_isolate, context);
+        _client = client;
+	}
+	~CV8InspectorChannel() override = default;
+    CV8InspectorClient* GetClient() 
+    {
+        return _client;
+    }
 
-		void sendNotification(std::unique_ptr<v8_inspector::StringBuffer> message)
-		{
-			Log::Debug << __FUNCTION__ << message->string().characters8();
-		}
+private:
+    void sendResponse(int callId, std::unique_ptr<v8_inspector::StringBuffer> message) override 
+    {
+        //Log::Info << __FUNCTION__ << " ID: " << callId << Log::Endl;;
+        Send(message->string());
+    }
+    void sendNotification(std::unique_ptr<v8_inspector::StringBuffer> message) override 
+    {
+        //Log::Info << __FUNCTION__ << Log::Endl;
+        Send(message->string());
+    }
+    void flushProtocolNotifications() override 
+    {
+        //Log::Info << __FUNCTION__ << Log::Endl;
+    }
+    void Send(const v8_inspector::StringView& string);
 
-		void flushProtocolNotifications()
-		{
-			Log::Debug << __FUNCTION__;
-		}
-	};
-} // namespace alt
+    v8::Isolate* _isolate;
+    v8::Global<v8::Context> _context;
+    CV8InspectorClient* _client;
+};

--- a/src/inspector/CV8InspectorChannel.h
+++ b/src/inspector/CV8InspectorChannel.h
@@ -2,7 +2,7 @@
 
 #include "v8-inspector.h"
 #include "../helpers/V8Helpers.h"
-#include "CV8InspectorClient.h";
+#include "CV8InspectorClient.h"
 
 class CV8InspectorChannel : public v8_inspector::V8Inspector::Channel
 {

--- a/src/inspector/CV8InspectorChannel.h
+++ b/src/inspector/CV8InspectorChannel.h
@@ -28,15 +28,14 @@ private:
     void sendNotification(std::unique_ptr<v8_inspector::StringBuffer> message) override 
     {
         //Log::Info << __FUNCTION__ << Log::Endl;
-
-        // TODO: Fix notifications sent by the inspector
-        //Send(-1, message->string());
+        SendEvent(message->string());
     }
     void flushProtocolNotifications() override 
     {
         //Log::Info << __FUNCTION__ << Log::Endl;
     }
     void Send(int id, const v8_inspector::StringView& string);
+    void SendEvent(const v8_inspector::StringView& string);
 
     v8::Isolate* _isolate;
     v8::Global<v8::Context> _context;

--- a/src/inspector/CV8InspectorClient.cpp
+++ b/src/inspector/CV8InspectorClient.cpp
@@ -33,7 +33,7 @@ CV8InspectorClient::CV8InspectorClient(v8::Local<v8::Context> context, bool conn
     _context.Reset(isolate, context);
 }
 
-static void CV8InspectorClient::SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info)
+void CV8InspectorClient::SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
     v8::Isolate* isolate = info.GetIsolate();
     v8::HandleScope handle_scope(isolate);

--- a/src/inspector/CV8InspectorClient.cpp
+++ b/src/inspector/CV8InspectorClient.cpp
@@ -23,7 +23,7 @@ v8::Local<v8::Promise> CV8InspectorClient::SendInspectorMessage(v8::Isolate* iso
 
     std::unique_ptr<uint16_t[]> method_buffer(new uint16_t[method.GetSize()]);
     v8::Local<v8::String> methodString = v8::String::NewFromUtf8(isolate, method.CStr()).ToLocalChecked();
-    methodString->Write(isolate, method_buffer, 0, method.GetSize());
+    methodString->Write(isolate, method_buffer.get(), 0, method.GetSize());
     v8_inspector::StringView method_view(method_buffer.get(), method.GetSize());
     if (!v8_inspector::V8InspectorSession::canDispatchMethod(method_view)) {
         V8Helpers::Throw(isolate, "Invalid protocol method passed");

--- a/src/inspector/CV8InspectorClient.cpp
+++ b/src/inspector/CV8InspectorClient.cpp
@@ -48,12 +48,11 @@ v8::Local<v8::Promise> CV8InspectorClient::SendInspectorMessage(v8::Isolate* iso
     promises.emplace(id, v8::Global<v8::Promise::Resolver>(isolate, resolver));
 
     auto paramsStringified = v8::JSON::Stringify(ctx, params).ToLocalChecked();
-
     v8::String::Utf8Value paramsUtf(isolate, paramsStringified);
     std::string paramsString(*paramsUtf);
 
     // This is a bad solution, too bad!
-    char paramsChar[256];
+    char paramsChar[1024];
     sprintf_s(paramsChar, "{ \"id\": %d, \"method\": \"%s\", \"params\": %s }", id, method.CStr(), paramsString.c_str());
     v8::Local<v8::String> message = v8::String::NewFromUtf8(
         isolate,

--- a/src/inspector/CV8InspectorClient.cpp
+++ b/src/inspector/CV8InspectorClient.cpp
@@ -1,0 +1,56 @@
+
+#include "CV8InspectorClient.h"
+#include "CV8InspectorChannel.h"
+
+CV8InspectorClient::CV8InspectorClient(v8::Local<v8::Context> context, bool connect)
+{
+    if (!connect) return;
+
+    _isolate = context->GetIsolate();
+    auto isolate = _isolate;
+    _channel.reset(new CV8InspectorChannel(context, this));
+    _inspector = v8_inspector::V8Inspector::create(isolate, this);
+    _session =
+        _inspector->connect(1, _channel.get(), v8_inspector::StringView());
+    context->SetAlignedPointerInEmbedderData(2, this);
+    _inspector->contextCreated(v8_inspector::V8ContextInfo(
+        context, 1, v8_inspector::StringView()));
+    v8::Local<v8::Value> function =
+        v8::FunctionTemplate::New(_isolate, SendInspectorMessage)
+        ->GetFunction(context)
+        .ToLocalChecked();
+    bool isSet =
+        context->Global()->Set(
+            context,
+            v8::String::NewFromUtf8(isolate, "__send").ToLocalChecked(),
+            function
+        ).FromJust();
+    if (!isSet) {
+        Log::Error << "Could not set global inspector send function" << Log::Endl;
+        return;
+    }
+
+    _context.Reset(isolate, context);
+}
+
+void CV8InspectorClient::SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    v8::Isolate* isolate = info.GetIsolate();
+    v8::HandleScope handle_scope(isolate);
+
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    V8_RETURN(v8::Undefined(isolate));
+
+    v8::Local<v8::String> message = info[0]->ToString(context).ToLocalChecked();
+
+    v8_inspector::V8InspectorSession* session =
+        CV8InspectorClient::GetSession(context);
+    std::unique_ptr<uint16_t[]> buffer(new uint16_t[message->Length()]);
+    message->Write(isolate, buffer.get(), 0, message->Length());
+    v8_inspector::StringView message_view(buffer.get(), message->Length());
+    {
+        v8::SealHandleScope seal_handle_scope(isolate);
+        session->dispatchProtocolMessage(message_view);
+    }
+    V8_RETURN_BOOLEAN(true);
+}

--- a/src/inspector/CV8InspectorClient.cpp
+++ b/src/inspector/CV8InspectorClient.cpp
@@ -15,8 +15,8 @@ CV8InspectorClient::CV8InspectorClient(v8::Local<v8::Context> context, bool conn
     context->SetAlignedPointerInEmbedderData(2, this);
     _inspector->contextCreated(v8_inspector::V8ContextInfo(
         context, 1, v8_inspector::StringView()));
-    v8::Local<v8::Value> function =
-        v8::FunctionTemplate::New(_isolate, SendInspectorMessage)
+    /*v8::Local<v8::Value> function =
+        v8::FunctionTemplate::New(_isolate, CV8InspectorClient::SendInspectorMessage)
         ->GetFunction(context)
         .ToLocalChecked();
     bool isSet =
@@ -28,12 +28,12 @@ CV8InspectorClient::CV8InspectorClient(v8::Local<v8::Context> context, bool conn
     if (!isSet) {
         Log::Error << "Could not set global inspector send function" << Log::Endl;
         return;
-    }
+    }*/
 
     _context.Reset(isolate, context);
 }
 
-void CV8InspectorClient::SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info)
+static void CV8InspectorClient::SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
     v8::Isolate* isolate = info.GetIsolate();
     v8::HandleScope handle_scope(isolate);

--- a/src/inspector/CV8InspectorClient.cpp
+++ b/src/inspector/CV8InspectorClient.cpp
@@ -27,7 +27,7 @@ v8::Local<v8::Promise> CV8InspectorClient::SendInspectorMessage(v8::Isolate* iso
     v8_inspector::StringView method_view(method_buffer.get(), method.GetSize());
     if (!v8_inspector::V8InspectorSession::canDispatchMethod(method_view)) {
         V8Helpers::Throw(isolate, "Invalid protocol method passed");
-        return;
+        return v8::Local<v8::Promise>();
     }
 
     v8::Local<v8::Context> ctx = isolate->GetCurrentContext();

--- a/src/inspector/CV8InspectorClient.cpp
+++ b/src/inspector/CV8InspectorClient.cpp
@@ -21,6 +21,15 @@ v8::Local<v8::Promise> CV8InspectorClient::SendInspectorMessage(v8::Isolate* iso
 {
     v8::HandleScope handle_scope(isolate);
 
+    std::unique_ptr<uint16_t[]> method_buffer(new uint16_t[method.GetSize()]);
+    v8::Local<v8::String> methodString = v8::String::NewFromUtf8(isolate, method.CStr()).ToLocalChecked();
+    methodString->Write(isolate, method_buffer, 0, method.GetSize());
+    v8_inspector::StringView method_view(method_buffer.get(), method.GetSize());
+    if (!v8_inspector::V8InspectorSession::canDispatchMethod(method_view)) {
+        V8Helpers::Throw(isolate, "Invalid protocol method passed");
+        return;
+    }
+
     v8::Local<v8::Context> ctx = isolate->GetCurrentContext();
     auto id = CV8InspectorClient::GetNextMessageId();
 
@@ -40,15 +49,15 @@ v8::Local<v8::Promise> CV8InspectorClient::SendInspectorMessage(v8::Isolate* iso
     sprintf_s(paramsChar, "{ \"id\": %d, \"method\": \"%s\", \"params\": %s }", id, method.CStr(), paramsString.c_str());
     v8::Local<v8::String> message = v8::String::NewFromUtf8(isolate, paramsChar).ToLocalChecked();
 
-    CV8ResourceImpl* resource = static_cast<CV8ResourceImpl*>(V8ResourceImpl::Get(ctx));
-    v8_inspector::V8InspectorSession* session = resource->GetInspector()->GetSession();
-
     std::unique_ptr<uint16_t[]> buffer(new uint16_t[message->Length()]);
     message->Write(isolate, buffer.get(), 0, message->Length());
 
     v8_inspector::StringView message_view(buffer.get(), message->Length());
     {
         v8::SealHandleScope seal_handle_scope(isolate);
+
+        CV8ResourceImpl* resource = static_cast<CV8ResourceImpl*>(V8ResourceImpl::Get(ctx));
+        v8_inspector::V8InspectorSession* session = resource->GetInspector()->GetSession();
         session->dispatchProtocolMessage(message_view);
     }
     return resolver->GetPromise();

--- a/src/inspector/CV8InspectorClient.h
+++ b/src/inspector/CV8InspectorClient.h
@@ -19,6 +19,17 @@ public:
         return _session.get();
     }
 
+    v8::Local<v8::Function> GetCallback(v8::Isolate* isolate)
+    {
+        if (_callback.IsEmpty()) return v8::Local<v8::Function>();
+        return _callback.Get(isolate);
+    }
+
+    void SetCallback(v8::Isolate* isolate, v8::Local<v8::Function> callback)
+    {
+        _callback.Reset(isolate, callback);
+    }
+
 private:
 
     v8::Local<v8::Context> ensureDefaultContextInGroup(int group_id) override 
@@ -34,6 +45,7 @@ private:
     std::unique_ptr<v8_inspector::V8Inspector::Channel> _channel;
     v8::Global<v8::Context> _context;
     v8::Isolate* _isolate;
+    v8::Global<v8::Function> _callback;
 
     static uint32_t GetNextMessageId();
     static uint32_t lastMessageId;

--- a/src/inspector/CV8InspectorClient.h
+++ b/src/inspector/CV8InspectorClient.h
@@ -1,11 +1,45 @@
 #pragma once
 
 #include "v8-inspector.h"
+#include "../helpers/V8Class.h"
 
-namespace alt
+class CV8InspectorClient : public v8_inspector::V8InspectorClient
 {
-	class CV8InspectorClient : public v8_inspector::V8InspectorClient
-	{
+public:
+    CV8InspectorClient(v8::Local<v8::Context> context, bool connect);
+   
+    v8::Local<v8::Function> GetCallback(v8::Isolate* isolate)
+    {
+        return _callback.Get(isolate);
+    }
+    void SetCallback(v8::Local<v8::Function> callback, v8::Isolate* isolate)
+    {
+        _callback.Reset(isolate, callback);
+    }
 
-	};
-}
+private:
+    static v8_inspector::V8InspectorSession* GetSession(v8::Local<v8::Context> context) 
+    {
+        CV8InspectorClient* inspector_client = static_cast<CV8InspectorClient*>(
+            context->GetAlignedPointerFromEmbedderData(2));
+        return inspector_client->_session.get();
+    }
+
+    v8::Local<v8::Context> ensureDefaultContextInGroup(int group_id) override 
+    {
+        auto isolate = _isolate;
+        //V8_CHECK(isolate, "Invalid isolate");
+        //V8_CHECK(group_id == 1, "Invalid context group id");
+        return _context.Get(isolate);
+    }
+
+    static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info);
+
+    std::unique_ptr<v8_inspector::V8Inspector> _inspector;
+    std::unique_ptr<v8_inspector::V8InspectorSession> _session;
+    std::unique_ptr<v8_inspector::V8Inspector::Channel> _channel;
+    v8::Global<v8::Context> _context;
+    v8::Isolate* _isolate;
+
+    v8::Global<v8::Function> _callback;
+};

--- a/src/inspector/CV8InspectorClient.h
+++ b/src/inspector/CV8InspectorClient.h
@@ -7,17 +7,10 @@ class CV8InspectorClient : public v8_inspector::V8InspectorClient
 {
 public:
     CV8InspectorClient(v8::Local<v8::Context> context, bool connect);
-   
-    v8::Local<v8::Function> GetCallback(v8::Isolate* isolate)
-    {
-        return _callback.Get(isolate);
-    }
-    void SetCallback(v8::Local<v8::Function> callback, v8::Isolate* isolate)
-    {
-        _callback.Reset(isolate, callback);
-    }
 
-    static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info);
+    static v8::Local<v8::Promise> SendInspectorMessage(v8::Isolate* isolate, alt::String method, v8::Local<v8::Object> params);
+
+    static std::unordered_map<uint32_t, v8::Global<v8::Promise::Resolver>> promises;
 
 private:
     static v8_inspector::V8InspectorSession* GetSession(v8::Local<v8::Context> context) 
@@ -41,5 +34,6 @@ private:
     v8::Global<v8::Context> _context;
     v8::Isolate* _isolate;
 
-    v8::Global<v8::Function> _callback;
+    static uint32_t GetNextMessageId();
+    static uint32_t lastMessageId;
 };

--- a/src/inspector/CV8InspectorClient.h
+++ b/src/inspector/CV8InspectorClient.h
@@ -17,6 +17,8 @@ public:
         _callback.Reset(isolate, callback);
     }
 
+    static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info);
+
 private:
     static v8_inspector::V8InspectorSession* GetSession(v8::Local<v8::Context> context) 
     {
@@ -32,8 +34,6 @@ private:
         //V8_CHECK(group_id == 1, "Invalid context group id");
         return _context.Get(isolate);
     }
-
-    static void SendInspectorMessage(const v8::FunctionCallbackInfo<v8::Value>& info);
 
     std::unique_ptr<v8_inspector::V8Inspector> _inspector;
     std::unique_ptr<v8_inspector::V8InspectorSession> _session;

--- a/src/inspector/CV8InspectorClient.h
+++ b/src/inspector/CV8InspectorClient.h
@@ -10,6 +10,7 @@ public:
     CV8InspectorClient(v8::Local<v8::Context> context, bool connect);
 
     static v8::Local<v8::Promise> SendInspectorMessage(v8::Isolate* isolate, alt::String method, v8::Local<v8::Object> params);
+    static v8::Local<v8::Promise> SendInspectorMessage(v8::Isolate* isolate, alt::String messageRaw);
 
     static std::unordered_map<uint32_t, v8::Global<v8::Promise::Resolver>> promises;
 

--- a/src/inspector/CV8InspectorClient.h
+++ b/src/inspector/CV8InspectorClient.h
@@ -2,6 +2,7 @@
 
 #include "v8-inspector.h"
 #include "../helpers/V8Class.h"
+#include "../CV8Resource.h"
 
 class CV8InspectorClient : public v8_inspector::V8InspectorClient
 {
@@ -12,13 +13,12 @@ public:
 
     static std::unordered_map<uint32_t, v8::Global<v8::Promise::Resolver>> promises;
 
-private:
-    static v8_inspector::V8InspectorSession* GetSession(v8::Local<v8::Context> context) 
+    v8_inspector::V8InspectorSession* GetSession()
     {
-        CV8InspectorClient* inspector_client = static_cast<CV8InspectorClient*>(
-            context->GetAlignedPointerFromEmbedderData(2));
-        return inspector_client->_session.get();
+        return _session.get();
     }
+
+private:
 
     v8::Local<v8::Context> ensureDefaultContextInGroup(int group_id) override 
     {


### PR DESCRIPTION
This is only a basic implementation and does not have any fancy wrapper around it.
See https://github.com/altmp/altv-issues/issues/652

API:
```ts
alt.Inspector.setEventCallback(callback: (message: string) => void): void
alt.Inspector.sendMessage(method: string, params: any): Promise<any>
alt.Inspector.sendMessageRaw(message: string): Promise<any>
```