### PR TITLE
Fix dynamic import after resource restart

### DIFF
--- a/src/CV8ScriptRuntime.h
+++ b/src/CV8ScriptRuntime.h
@@ -12,6 +12,7 @@ class CV8ScriptRuntime : public alt::IScriptRuntime
 {
 	static constexpr char inspectorViewStr[] = "alt:V Multiplayer";
 
+	std::unordered_set<CV8ResourceImpl*> resources;
 	std::unique_ptr<v8::Platform> platform;
 	v8::Isolate::CreateParams create_params;
 	v8::Isolate *isolate;
@@ -31,12 +32,16 @@ public:
 
 	alt::IResource::Impl *CreateImpl(alt::IResource *resource) override
 	{
-		return new CV8ResourceImpl(resource, isolate);
+		auto res = new CV8ResourceImpl(resource, isolate);
+		resources.insert(res);
+		return res;
 	}
 
 	void DestroyImpl(alt::IResource::Impl *impl) override
 	{
-		delete static_cast<CV8ResourceImpl *>(impl);
+		auto res = static_cast<CV8ResourceImpl *>(impl);
+		resources.erase(res);
+		delete res;
 	}
 
 	void OnTick() override
@@ -46,6 +51,11 @@ public:
 		v8::HandleScope handle_scope(isolate);
 
 		v8::platform::PumpMessageLoop(platform.get(), isolate);
+	}
+
+	std::unordered_set<CV8ResourceImpl*> GetResources()
+	{
+		return resources;
 	}
 
 	void HeapBenchmark()


### PR DESCRIPTION
Draft until a method for C++ SDK is added to get resources of the runtime
See https://github.com/altmp/altv-issues/issues/771