### PR TITLE
Add alt.Voice.activationKey and move old Voice method to Voice class

### DIFF
--- a/src/bindings/Main.cpp
+++ b/src/bindings/Main.cpp
@@ -189,6 +189,8 @@ static void IsVoiceActivityInputEnabled(const v8::FunctionCallbackInfo<v8::Value
 {
 	V8_GET_ISOLATE_CONTEXT();
 
+	Log::Warning << "alt.isVoiceActivityInputEnabled is deprecated and will be removed in the future. Please use alt.Voice.activityInputEnabled" << Log::Endl;
+
 	V8_RETURN_BOOLEAN(ICore::Instance().IsVoiceActivationEnabled());
 }
 

--- a/src/bindings/Voice.cpp
+++ b/src/bindings/Voice.cpp
@@ -3,13 +3,14 @@
 #include "../helpers/V8ResourceImpl.h"
 #include "../helpers/V8Class.h"
 
-static void StaticGetInputMuted(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value> &info)
+static void StaticGetInputMuted(v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Value> &info)
 {
 	V8_GET_ISOLATE_CONTEXT();
+	
 	V8_RETURN_BOOLEAN(alt::ICore::Instance().IsVoiceInputMuted());
 }
 
-static void StaticSetInputMuted(v8::Local<v8::String> name, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<void> &info)
+static void StaticSetInputMuted(v8::Local<v8::String>, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<void> &info)
 {
 	V8_GET_ISOLATE_CONTEXT();
 	V8_TO_BOOLEAN(value, state);
@@ -17,8 +18,24 @@ static void StaticSetInputMuted(v8::Local<v8::String> name, v8::Local<v8::Value>
 	alt::ICore::Instance().SetVoiceInputMuted(state);
 }
 
+static void StaticGetVoiceActivityInputEnabled(v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Value> &info)
+{
+	V8_GET_ISOLATE_CONTEXT();
+
+	V8_RETURN_BOOLEAN(alt::ICore::Instance().IsVoiceActivationEnabled());
+}
+
+static void StaticGetVoiceActivationKey(v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Value> &info)
+{
+	V8_GET_ISOLATE_CONTEXT();
+
+	V8_RETURN_UINT32(alt::ICore::Instance().GetVoiceActivationKey());
+}
+
 extern V8Class v8Voice("Voice", [](v8::Local<v8::FunctionTemplate> tpl) {
 	v8::Isolate *isolate = v8::Isolate::GetCurrent();
 
 	V8::SetStaticAccessor(isolate, tpl, "muteInput", StaticGetInputMuted, StaticSetInputMuted);
+	V8::SetStaticAccessor(isolate, tpl, "activityInputEnabled", StaticGetVoiceActivityInputEnabled);
+	V8::SetStaticAccessor(isolate, tpl, "activationKey", StaticGetVoiceActivationKey);
 });


### PR DESCRIPTION
- Added the new `alt.Voice.activationKey` property
- Moved `alt.getVoiceActivityInputEnabled` to the Voice class as `alt.Voice.activityInputEnabled`
- Deprecated `alt.getVoiceActivityInputEnabled` with a warning message
- (Did some small aesthetic code changes)
