### PR TITLE
Add evalModule function

### DIFF
--- a/src/CV8Resource.cpp
+++ b/src/CV8Resource.cpp
@@ -140,6 +140,7 @@ bool CV8ResourceImpl::Start()
 		ctx->Global()->Set(ctx, V8_NEW_STRING("clearTimeout"), exports->Get(ctx, V8_NEW_STRING("clearTimeout")).ToLocalChecked());
 
 		ctx->Global()->Set(ctx, v8::String::NewFromUtf8(isolate, "__internal_get_exports").ToLocalChecked(), v8::Function::New(ctx, &StaticRequire).ToLocalChecked());
+
 		bool res = curModule->InstantiateModule(ctx, CV8ScriptRuntime::ResolveModule).IsJust();
 
 		if (!res)
@@ -598,11 +599,6 @@ v8::MaybeLocal<v8::Module> CV8ResourceImpl::ResolveModule(const std::string &_na
 		maybeModule = ResolveFile(name, referrer);
 	}
 
-	if(maybeModule.IsEmpty())
-	{
-		maybeModule = CompileESM(isolate, "[import]", name);
-	}
-
 	if (maybeModule.IsEmpty())
 	{
 		modules.erase(name);
@@ -617,6 +613,16 @@ v8::MaybeLocal<v8::Module> CV8ResourceImpl::ResolveModule(const std::string &_na
 		isolate->ThrowException(v8::Exception::ReferenceError(v8::String::NewFromUtf8(isolate, ("Failed to import: " + name).c_str())));
 		return v8::MaybeLocal<v8::Module>{ };
 	}*/
+
+	return maybeModule;
+}
+
+v8::MaybeLocal<v8::Module> CV8ResourceImpl::ResolveCode(const std::string& code, const V8::SourceLocation& location) 
+{
+	v8::MaybeLocal<v8::Module> maybeModule;
+	std::stringstream name;
+	name << "[module " << location.GetFileName() << ":" << location.GetLineNumber() << "]";
+	maybeModule = CompileESM(isolate, name.str(), code);
 
 	return maybeModule;
 }

--- a/src/CV8Resource.cpp
+++ b/src/CV8Resource.cpp
@@ -46,7 +46,8 @@ static void StaticRequire(const v8::FunctionCallbackInfo<v8::Value> &info)
 		V8Helpers::Throw(isolate, "No such module " + name);
 }
 
-void CV8ResourceImpl::ProcessDynamicImports() {
+void CV8ResourceImpl::ProcessDynamicImports() 
+{
 	for(auto import : dynamicImports)
 	{
 		import();
@@ -595,6 +596,11 @@ v8::MaybeLocal<v8::Module> CV8ResourceImpl::ResolveModule(const std::string &_na
 	if (maybeModule.IsEmpty())
 	{
 		maybeModule = ResolveFile(name, referrer);
+	}
+
+	if(maybeModule.IsEmpty())
+	{
+		maybeModule = CompileESM(isolate, "[import]", name);
 	}
 
 	if (maybeModule.IsEmpty())

--- a/src/CV8Resource.h
+++ b/src/CV8Resource.h
@@ -122,6 +122,7 @@ public:
 	v8::MaybeLocal<v8::Value> Require(const std::string &name);
 	v8::MaybeLocal<v8::Module> ResolveFile(const std::string &name, v8::Local<v8::Module> referrer);
 	v8::MaybeLocal<v8::Module> ResolveModule(const std::string &name, v8::Local<v8::Module> referrer);
+	v8::MaybeLocal<v8::Module> ResolveCode(const std::string& code, const V8::SourceLocation& location);
 
 private:
 	using WebViewEvents = std::unordered_multimap<std::string, V8::EventCallback>;

--- a/src/bindings/Main.cpp
+++ b/src/bindings/Main.cpp
@@ -711,6 +711,38 @@ static void LoadModelAsync(const v8::FunctionCallbackInfo<v8::Value>& info)
 	Log::Warning << "loadModelAsync is deprecated and it will be removed in the future. Please use the native requestModel." << Log::Endl;
 }
 
+static void EvalModule(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+	V8_GET_ISOLATE_CONTEXT_RESOURCE();
+
+	V8_CHECK_ARGS_LEN(1);
+	V8_ARG_TO_STRING(1, code);
+
+	auto maybeModule = static_cast<CV8ResourceImpl*>(resource)->ResolveCode(code.ToString(), V8::SourceLocation::GetCurrent(isolate));
+	if(maybeModule.IsEmpty())
+	{
+		V8Helpers::Throw(isolate, "Failed to resolve module");
+		return;
+	}
+
+	auto module = maybeModule.ToLocalChecked();
+	v8::Maybe<bool> result = module->InstantiateModule(ctx, CV8ScriptRuntime::ResolveModule);
+	if(result.IsNothing() || result.ToChecked() == false)
+	{
+		V8Helpers::Throw(isolate, "Failed to instantiate module");
+		return;
+	}
+
+	auto returnValue = module->Evaluate(ctx);
+	if(returnValue.IsEmpty())
+	{
+		V8Helpers::Throw(isolate, "Failed to evaluate module");
+		return;
+	}
+
+	V8_RETURN(module->GetModuleNamespace());
+}
+
 extern V8Class v8Vector3,
 	v8Vector2,
 	v8RGBA,
@@ -842,4 +874,6 @@ extern V8Module altModule(
 
 		V8Helpers::RegisterFunc(exports, "loadYtyp", &LoadYtyp);
 		V8Helpers::RegisterFunc(exports, "unloadYtyp", &UnloadYtyp);
+
+		V8Helpers::RegisterFunc(exports, "evalModule", &EvalModule);
 	});


### PR DESCRIPTION
Adds a function to eval a module.
```js
alt.evalModule("import * as alt from 'alt'; alt.log('Hello World')");
```