### PR TITLE
Allow float as int native arg

### DIFF
--- a/src/bindings/V8Natives.cpp
+++ b/src/bindings/V8Natives.cpp
@@ -107,7 +107,7 @@ static void PushArg(alt::Ref<alt::INative::Context> scrCtx, alt::INative* native
 		break;
 	case alt::INative::Type::ARG_INT32:
 	{
-		if (val->IsUint32() || val->IsInt32())
+		if (val->IsNumber())
 		{
 			v8::Local<v8::Integer> value;
 			if (val->ToInteger(v8Ctx).ToLocal(&value))
@@ -151,7 +151,7 @@ static void PushArg(alt::Ref<alt::INative::Context> scrCtx, alt::INative* native
 		break;
 	case alt::INative::Type::ARG_UINT32:
 	{
-		if (val->IsUint32() || val->IsInt32())
+		if (val->IsNumber())
 		{
 			v8::Local<v8::Integer> value;
 			if (val->ToInteger(v8Ctx).ToLocal(&value))

--- a/src/bindings/V8Natives.cpp
+++ b/src/bindings/V8Natives.cpp
@@ -190,10 +190,18 @@ static void PushArg(alt::Ref<alt::INative::Context> scrCtx, alt::INative* native
 		break;
 	case alt::INative::Type::ARG_FLOAT:
 	{
-		v8::Local<v8::Number> value;
-		if (val->ToNumber(v8Ctx).ToLocal(&value))
+		if (val->IsNumber())
 		{
-			scrCtx->Push((float)value->Value());
+			v8::Local<v8::Number> value;
+			if (val->ToNumber(v8Ctx).ToLocal(&value))
+			{
+				scrCtx->Push((float)value->Value());
+			}
+			else
+			{
+				v8::String::Utf8Value type(isolate, val->TypeOf(isolate));
+				Log::Error << "Native argument " << "(" << *type << ")" << " could not be parsed to type " << GetNativeTypeName(argType) << " (" << native->GetName() << ")" << Log::Endl;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Allows passing floats for native arguments that require an int32 or uint32. The float gets truncated to an integer, so the fractional part is lost, but this should be fine because the native doesn't want a float anyway.
Also added the same checks in int32 and uint32 to the float arg, as it *could* also cause a crash